### PR TITLE
Bump all dependencies in one go

### DIFF
--- a/scripts/do-release.sh
+++ b/scripts/do-release.sh
@@ -76,17 +76,18 @@ function _update_go_mod() {
     [[ -z "$SKIP_WHEN_TESTING" ]] || { echo "SKIPPING: ${FUNCNAME[0]}" && return 0; }
     local target_version=${release['branch']:-devel}
     dryrun eval target_version="${release['version']}"
-    dryrun export GONOPROXY="github.com/submariner-io/${target}"
 
-    go mod tidy -compat=1.17
-    go get "github.com/submariner-io/${target}@${target_version}"
-    go mod tidy -compat=1.17
-    go mod vendor
+    awk '/github.com\/submariner-io.* v/ { print $1 }' go.mod | while read -r target; do
+        dryrun export GONOPROXY="${target}"
+
+        go mod tidy
+        go get "${target}@${target_version}"
+        go mod tidy
+        go mod vendor
+    done
 }
 
 function update_go_mod() {
-    local target="$1"
-
     shopt -s globstar
     for gomod in projects/"${project}"/**/go.mod; do
         dir="${gomod%/*}"
@@ -101,17 +102,12 @@ function update_go_mod() {
 }
 
 function update_dependencies() {
-    local msg="$1"
-    shift
-
     clone_and_create_branch "update-dependencies-${release['branch']:-devel}"
 
-    for dependency; do
-        update_go_mod "$dependency"
-    done
+    [ ! -f "projects/${project}/go.mod" ] || update_go_mod "$dependency"
 
     run_if_defined "$update_dependencies_extra"
-    create_pr "Update ${msg} to ${release['version']}"
+    create_pr "Update Submariner dependencies to ${release['version']}"
 }
 
 function push_to_repo() {
@@ -227,7 +223,7 @@ function release_shipyard() {
 
     # Create a PR to pin Shipyard on every one of its consumers
     for project in "${SHIPYARD_CONSUMERS[@]}"; do
-        record_errors update_dependencies Shipyard shipyard
+        record_errors update_dependencies
     done
 }
 
@@ -240,7 +236,7 @@ function release_admiral() {
 
     # Create a PR to pin Admiral on every one of it's consumers
     for project in "${ADMIRAL_CONSUMERS[@]}"; do
-        record_errors update_dependencies Admiral admiral
+        record_errors update_dependencies
     done
 }
 
@@ -261,7 +257,7 @@ function release_projects() {
     # Create a PR for operator to use these versions
     local project="submariner-operator"
     local update_dependencies_extra=update_operator_versions
-    record_errors update_dependencies Operator "${OPERATOR_CONSUMES[@]}"
+    record_errors update_dependencies
 }
 
 ### Functions: Installers Stage ###
@@ -271,12 +267,12 @@ function release_installers() {
 
     # Create a PR for subctl to use these versions
     local project="subctl"
-    record_errors update_dependencies Subctl "${SUBCTL_CONSUMES[@]}"
+    record_errors update_dependencies
 
     # Create a PR in submariner-charts to update the CHARTS_VERSION in the Makefile
     local project="submariner-charts"
     local update_dependencies_extra=update_charts_versions
-    record_errors update_dependencies Charts
+    record_errors update_dependencies
 }
 
 ### Functions: Released Stage ###

--- a/scripts/lib/utils
+++ b/scripts/lib/utils
@@ -3,10 +3,8 @@
 
 readonly PROJECTS=(admiral cloud-prepare lighthouse shipyard subctl submariner submariner-charts submariner-operator)
 readonly REPO="quay.io/submariner"
-readonly ADMIRAL_CONSUMERS=(cloud-prepare lighthouse subctl submariner submariner-operator)
-readonly SHIPYARD_CONSUMERS=(admiral lighthouse subctl submariner submariner-operator)
-readonly OPERATOR_CONSUMES=(submariner lighthouse)
-readonly SUBCTL_CONSUMES=(submariner submariner-operator cloud-prepare lighthouse)
+readonly ADMIRAL_CONSUMERS=(cloud-prepare lighthouse submariner)
+readonly SHIPYARD_CONSUMERS=(admiral)
 readonly PROJECTS_PROJECTS=(cloud-prepare lighthouse submariner)
 readonly INSTALLER_PROJECTS=(submariner-operator)
 readonly RELEASED_PROJECTS=(subctl submariner-charts)


### PR DESCRIPTION
Instead of trickling down dependency bumps, this applies all dependency upgrades in a single PR per project. This doesn't change anything for shipyard; then:
* once shipyard is released, only admiral is upgraded
* once admiral is released, cloud-prepare, lighthouse and submariner are upgraded (with the new releases of both shipyard and admiral)
* once cloud-prepare, lighthouse, and submariner are released, submariner-operator is upgraded
* once submariner-operator is released, subctl is upgraded

This reduces the overall number of PRs needed for a release, and ensures that each project gets a consistent set of upgrades (avoiding breakage related e.g. to API changes in one project requiring simultaneous upgrades of all affected dependencies in the operator or subctl).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
